### PR TITLE
Update settings.py to include DEFAULT_SCHEMA_CLASS

### DIFF
--- a/ch9-schemas-and-documentation/blog_project/settings.py
+++ b/ch9-schemas-and-documentation/blog_project/settings.py
@@ -141,6 +141,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
     ],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema'
 }
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' # new


### PR DESCRIPTION
I couldn't get the docs working. Here is the solution https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi

I'm enjoying a lot reading your books. Thank you very much!