### PR TITLE
add __str__ to CustomUser model in chapter6

### DIFF
--- a/ch6-blog-api/accounts/models.py
+++ b/ch6-blog-api/accounts/models.py
@@ -4,3 +4,6 @@ from django.db import models
 
 class CustomUser(AbstractUser):
     name = models.CharField(null=True, blank=True, max_length=100)
+
+    def __str__(self):
+        return self.email


### PR DESCRIPTION
Hi,
In chapter 6, We created a new `CustomUser` for our app. In page 93 you mentioned:

> We’ll also add a `__str__` method to return the user’s email address in the admin and elsewhere.

But there is no `__str__` there.
thanks.